### PR TITLE
Feat/prediction banner

### DIFF
--- a/app/bets/page.tsx
+++ b/app/bets/page.tsx
@@ -1,8 +1,11 @@
 'use client';
+
+import styled from 'styled-components';
+
 import MainTopBar from '@/components/MainTopBar';
 import NavigationBar from '@/components/NavigationBar';
 import { useShareModal } from '@/components/ShareModal';
-import styled from 'styled-components';
+import PredictionBanner from '@/components/PredictionBanner';
 
 export default function Bets() {
   const { openShareModal } = useShareModal();
@@ -18,6 +21,7 @@ export default function Bets() {
         <button style={{ color: 'white', fontSize: '20px' }} onClick={openModal}>
           공유
         </button>
+        <PredictionBanner />
       </Wrapper>
     </div>
   );

--- a/app/bets/page.tsx
+++ b/app/bets/page.tsx
@@ -6,12 +6,23 @@ import MainTopBar from '@/components/MainTopBar';
 import NavigationBar from '@/components/NavigationBar';
 import { useShareModal } from '@/components/ShareModal';
 import PredictionBanner from '@/components/PredictionBanner';
+import SportsSelectionBar from '@/components/SportsSelectionBar';
+import { useCallback, useState } from 'react';
+import { SelectionType } from '@/components/SportsSelectionBar/constants';
 
 export default function Bets() {
   const { openShareModal } = useShareModal();
+
+  // "Baseball" | "Soccer" | "Basketball" | "Rugby" | "Hockey"로 관리
+  const [curNav, setCurNav] = useState<SelectionType>('Baseball');
+
   async function openModal() {
     await openShareModal();
   }
+
+  const handleNav = useCallback((selection: SelectionType) => {
+    setCurNav(selection);
+  }, []);
 
   return (
     <div>
@@ -19,6 +30,8 @@ export default function Bets() {
       <NavigationBar />
       <Wrapper>
         <PredictionBanner shareHandler={openModal} />
+        <SportsSelectionBar curSelection={curNav} handleSelect={handleNav} isSticky />
+        <DummyScroll />
       </Wrapper>
     </div>
   );
@@ -26,4 +39,10 @@ export default function Bets() {
 
 const Wrapper = styled.div`
   padding-top: ${(props) => props.theme.space.mainTopBarHeight + props.theme.space.navigationBarHeight}px;
+`;
+
+// TODO: 지우기
+const DummyScroll = styled.div`
+  width: 10px;
+  height: 500vh;
 `;

--- a/app/bets/page.tsx
+++ b/app/bets/page.tsx
@@ -18,10 +18,7 @@ export default function Bets() {
       <MainTopBar />
       <NavigationBar />
       <Wrapper>
-        <button style={{ color: 'white', fontSize: '20px' }} onClick={openModal}>
-          공유
-        </button>
-        <PredictionBanner />
+        <PredictionBanner shareHandler={openModal} />
       </Wrapper>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,7 @@ export default function Home() {
       borderRadius="99px"
       padding="8px 16px"
       fontSize="14px"
+      fontWeight="700"
     >
       <Icon.TablerCopy />내 초대링크
     </ActionButton>

--- a/components/ActionButton/ActionButton.tsx
+++ b/components/ActionButton/ActionButton.tsx
@@ -12,6 +12,7 @@ interface ActionButtonProps {
   borderRadius?: string;
   href?: string;
   padding?: string;
+  fontWeight?: string;
 }
 
 export function ActionButton({
@@ -25,6 +26,7 @@ export function ActionButton({
   href,
   fontSize,
   padding,
+  fontWeight,
 }: ActionButtonProps) {
   return (
     <>
@@ -38,6 +40,7 @@ export function ActionButton({
             borderRadius={borderRadius}
             fontSize={fontSize}
             padding={padding}
+            fontWeight={fontWeight}
           >
             {children}
           </Wrapper>
@@ -52,6 +55,7 @@ export function ActionButton({
           fontSize={fontSize}
           onClick={onClick}
           padding={padding}
+          fontWeight={fontWeight}
         >
           {children}
         </Wrapper>
@@ -61,7 +65,7 @@ export function ActionButton({
 }
 
 const Wrapper = styled.div<ActionButtonProps>`
-  background-color: ${({ bgColor }) => bgColor || 'transparent'};
+  background: ${({ bgColor }) => bgColor || 'transparent'};
   color: ${({ color }) => color};
   display: flex;
   justify-content: center;
@@ -73,4 +77,5 @@ const Wrapper = styled.div<ActionButtonProps>`
   font-family: 'Spoqa Han Sans Neo';
   cursor: pointer;
   padding: ${({ padding }) => padding || '0'};
+  font-weight: ${({ fontWeight }) => fontWeight || '500'};
 `;

--- a/components/NavigationBar/NavigationBar.tsx
+++ b/components/NavigationBar/NavigationBar.tsx
@@ -37,7 +37,7 @@ const Wrapper = styled.div`
 
   width: 100%;
   height: ${({ theme }) => theme.space.navigationBarHeight}px;
-  background-color: ${({ theme }) => theme.colors.navigationBar};
+  background: ${({ theme }) => theme.colors.navigationBar};
 `;
 
 const NavigationItem = styled.div<{ selected: boolean }>`

--- a/components/PredictionBanner/PredictionBanner.tsx
+++ b/components/PredictionBanner/PredictionBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import ActionButton from '@/components/ActionButton';
+import { Flex } from '@/libs/design-system/flex';
+import styled from 'styled-components';
+
+export function PredictionBanner() {
+  return (
+    <Wrapper>
+      <Title>
+        {/* TODO: 저작권 명확히 한 후, SVG 또는 웹폰트 적용 */}
+        <div style={{ fontSize: '16px' }}>2024 정기전 토키</div>
+        <div style={{ fontSize: '43.5px' }}>승부예측</div>
+      </Title>
+      {/* TODO: 버튼에 액션 적용 */}
+      <Flex $gap="6px">
+        <ActionButton color="white" bgColor="#FFFFFF26" fontSize="14px" padding="8px 16px" borderRadius="99px">
+          더 알아보기
+        </ActionButton>
+        <ActionButton
+          color="white"
+          bgColor="linear-gradient(90deg, rgba(134, 0, 240, 0.80) -12.75%, rgba(70, 0, 183, 0.80) 113.73%)"
+          fontSize="14px"
+          padding="8px 16px"
+          borderRadius="99px"
+          fontWeight="700"
+        >
+          내 예측 공유하기
+        </ActionButton>
+      </Flex>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  width: 100%;
+  height: 170px;
+  background: linear-gradient(90deg, rgba(76, 14, 176, 0.4) 0%, rgba(76, 14, 176, 0.24) 100%),
+    linear-gradient(0deg, rgba(18, 18, 18, 0.15) 0%, rgba(18, 18, 18, 0) 100%);
+  padding-top: 30px;
+  padding-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 19.71px;
+`;
+
+const Title = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4.71px;
+  color: white;
+`;

--- a/components/PredictionBanner/PredictionBanner.tsx
+++ b/components/PredictionBanner/PredictionBanner.tsx
@@ -4,7 +4,10 @@ import ActionButton from '@/components/ActionButton';
 import { Flex } from '@/libs/design-system/flex';
 import styled from 'styled-components';
 
-export function PredictionBanner() {
+interface PredictionBannerProps {
+  shareHandler: () => void;
+}
+export function PredictionBanner({ shareHandler }: PredictionBannerProps) {
   return (
     <Wrapper>
       <Title>
@@ -12,8 +15,8 @@ export function PredictionBanner() {
         <div style={{ fontSize: '16px' }}>2024 정기전 토키</div>
         <div style={{ fontSize: '43.5px' }}>승부예측</div>
       </Title>
-      {/* TODO: 버튼에 액션 적용 */}
       <Flex $gap="6px">
+        {/* TODO: 더 알아보기 버튼에 액션 적용 */}
         <ActionButton color="white" bgColor="#FFFFFF26" fontSize="14px" padding="8px 16px" borderRadius="99px">
           더 알아보기
         </ActionButton>
@@ -24,6 +27,7 @@ export function PredictionBanner() {
           padding="8px 16px"
           borderRadius="99px"
           fontWeight="700"
+          onClick={shareHandler}
         >
           내 예측 공유하기
         </ActionButton>

--- a/components/PredictionBanner/index.ts
+++ b/components/PredictionBanner/index.ts
@@ -1,0 +1,1 @@
+export { PredictionBanner as default } from '@/components/PredictionBanner/PredictionBanner';

--- a/components/SportsSelectionBar/SportsButton.tsx
+++ b/components/SportsSelectionBar/SportsButton.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import styled from 'styled-components';
+
+interface SportsButtonProps {
+  isSelected: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+  hasUnderbar: boolean;
+}
+export function SportsButton({ isSelected, onClick, children, hasUnderbar }: SportsButtonProps) {
+  return (
+    <Wrapper $selected={isSelected} onClick={onClick}>
+      {children}
+      <UnderBar $show={hasUnderbar && isSelected} />
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.button<{ $selected: boolean }>`
+  display: flex;
+  padding-top: 12px;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 16px;
+  color: ${({ $selected }) => {
+    return $selected ? '#FFFFFFDE' : '#ffffff61';
+  }};
+`;
+
+const UnderBar = styled.div<{ $show: boolean }>`
+  height: 2px;
+  width: 100%;
+  background: #ffffffde;
+  border-top-right-radius: 99px;
+  border-top-left-radius: 99px;
+  ${({ $show }) => !$show && 'visibility: hidden;'}
+`;

--- a/components/SportsSelectionBar/SportsButton.tsx
+++ b/components/SportsSelectionBar/SportsButton.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { motion } from 'framer-motion';
 import styled from 'styled-components';
 
 interface SportsButtonProps {
@@ -11,27 +12,32 @@ export function SportsButton({ isSelected, onClick, children, hasUnderbar }: Spo
   return (
     <Wrapper $selected={isSelected} onClick={onClick}>
       {children}
-      <UnderBar $show={hasUnderbar && isSelected} />
+      {hasUnderbar && isSelected && <UnderBar layoutId="underbar" transition={{ duration: 0.15 }} />}
     </Wrapper>
   );
 }
 
 const Wrapper = styled.button<{ $selected: boolean }>`
+  position: relative;
+  height: 44px;
+  width: 36px;
   display: flex;
-  padding-top: 12px;
-  flex-direction: column;
-  gap: 10px;
+  justify-content: center;
+  align-items: center;
   font-size: 16px;
+  transition: all 0.15s;
   color: ${({ $selected }) => {
     return $selected ? '#FFFFFFDE' : '#ffffff61';
   }};
 `;
 
-const UnderBar = styled.div<{ $show: boolean }>`
+const UnderBar = styled(motion.div)`
+  position: absolute;
+  bottom: 0;
+  left: 0;
   height: 2px;
   width: 100%;
   background: #ffffffde;
   border-top-right-radius: 99px;
   border-top-left-radius: 99px;
-  ${({ $show }) => !$show && 'visibility: hidden;'}
 `;

--- a/components/SportsSelectionBar/SportsSelectionBar.tsx
+++ b/components/SportsSelectionBar/SportsSelectionBar.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import styled from 'styled-components';
+
+import { SelectionArray, SelectionType } from '@/components/SportsSelectionBar/constants';
+import { memo } from 'react';
+import { SportsButton } from '@/components/SportsSelectionBar/SportsButton';
+
+interface SportsSelectionBarProps {
+  curSelection: SelectionType;
+  handleSelect: (selection: SelectionType) => void;
+  bgColor?: string; // 커스텀 배경색
+  isAllNav?: boolean; // "전체" 항목의 표시 여부
+  hasUnderbar?: boolean; // 선택된 nav 항목 아래에 밑줄 표시 여부
+  isSticky?: boolean; // position : sticky 여부
+}
+export const SportsSelectionBar = memo(function SportsSelectionBar({
+  curSelection,
+  handleSelect,
+  bgColor,
+  isAllNav = false,
+  hasUnderbar = true,
+  isSticky = false,
+}: SportsSelectionBarProps) {
+  return (
+    <Wrapper $bgColor={bgColor} isSticky={isSticky}>
+      {isAllNav && (
+        <SportsButton isSelected={curSelection === 'All'} onClick={() => handleSelect('All')} hasUnderbar={hasUnderbar}>
+          전체
+        </SportsButton>
+      )}
+      {SelectionArray.map((sport) => (
+        <SportsButton
+          key={sport.title}
+          isSelected={curSelection === sport.type}
+          onClick={() => handleSelect(sport.type)}
+          hasUnderbar={hasUnderbar}
+        >
+          {sport.title}
+        </SportsButton>
+      ))}
+    </Wrapper>
+  );
+});
+
+const Wrapper = styled.div<{ $bgColor?: string; isSticky: boolean }>`
+  top: ${(props) => props.theme.space.mainTopBarHeight + props.theme.space.navigationBarHeight}px;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 20px;
+  ${({ isSticky }) => isSticky && 'position: sticky;'}
+  background: ${({ $bgColor }) =>
+    $bgColor ||
+    'linear-gradient(0deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.05)),linear-gradient(90deg, rgba(76, 14, 176, 0.4) -12.75%, rgba(76, 14, 176, 0.24) 113.73%);'};
+`;

--- a/components/SportsSelectionBar/SportsSelectionBar.tsx
+++ b/components/SportsSelectionBar/SportsSelectionBar.tsx
@@ -10,7 +10,7 @@ interface SportsSelectionBarProps {
   curSelection: SelectionType;
   handleSelect: (selection: SelectionType) => void;
   bgColor?: string; // 커스텀 배경색
-  isAllNav?: boolean; // "전체" 항목의 표시 여부
+  showAll?: boolean; // "전체" 항목의 표시 여부
   hasUnderbar?: boolean; // 선택된 nav 항목 아래에 밑줄 표시 여부
   isSticky?: boolean; // position : sticky 여부
 }
@@ -18,13 +18,13 @@ export const SportsSelectionBar = memo(function SportsSelectionBar({
   curSelection,
   handleSelect,
   bgColor,
-  isAllNav = false,
+  showAll = false,
   hasUnderbar = true,
   isSticky = false,
 }: SportsSelectionBarProps) {
   return (
     <Wrapper $bgColor={bgColor} isSticky={isSticky}>
-      {isAllNav && (
+      {showAll && (
         <SportsButton isSelected={curSelection === 'All'} onClick={() => handleSelect('All')} hasUnderbar={hasUnderbar}>
           전체
         </SportsButton>

--- a/components/SportsSelectionBar/constants.ts
+++ b/components/SportsSelectionBar/constants.ts
@@ -1,0 +1,9 @@
+export const SelectionArray = [
+  { type: 'Baseball', title: '야구' },
+  { type: 'Soccer', title: '축구' },
+  { type: 'Basketball', title: '농구' },
+  { type: 'Rugby', title: '럭비' },
+  { type: 'Hockey', title: '빙구' },
+] as const;
+
+export type SelectionType = (typeof SelectionArray)[number]['type'] | 'All';

--- a/components/SportsSelectionBar/index.ts
+++ b/components/SportsSelectionBar/index.ts
@@ -1,0 +1,1 @@
+export { SportsSelectionBar as default } from './SportsSelectionBar';


### PR DESCRIPTION
승부 예측 페이지 상단에 표시되는 배너를 구현하였습니다.

<img width="332" alt="Screenshot 2024-07-26 at 8 36 34 PM" src="https://github.com/user-attachments/assets/e959f6b7-6d37-454a-b452-2418229a5d6f">

버튼 액션과 폰트는 아직 적용되지 않았고, 
폰트 저작권 문제, SVG/폰트 표현 방식, 각 버튼 플로우가 명확해지면 추가하도록 하겠습니다.

구현하면서 그라디언트 배경색이 제대로 들어가지 않는 문제가 있어서, 
gradient 함수가 들어가는 속성을 background-color에서 background로 교체했고,
승준님이 구현해주신 ActionButton을 재활용하면서 font-weight를 적용했습니다.
