### PR TITLE
mod: user info 디자인 변경사항 적용

### DIFF
--- a/components/InputBox/InputBox.tsx
+++ b/components/InputBox/InputBox.tsx
@@ -17,6 +17,7 @@ interface InputBoxProps {
     text: string;
     onClick: () => void;
   };
+  changeable?: boolean;
 }
 export function InputBox({
   type = 'new',
@@ -27,6 +28,7 @@ export function InputBox({
   error = false,
   validationButton,
   clearError,
+  changeable = false,
 }: InputBoxProps) {
   const [status, setStatus] = useState<StatusType>('default');
   const errorState = useSignupError();
@@ -36,6 +38,7 @@ export function InputBox({
       <Input
         $status={status}
         $error={error}
+        $changeable={changeable}
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder={placeholder}
@@ -64,7 +67,7 @@ const Wrapper = styled.div`
   display: flex;
   flex-direction: column;
 `;
-const Input = styled.input<{ $status: StatusType; $error?: boolean }>`
+const Input = styled.input<{ $status: StatusType; $error?: boolean; $changeable?: boolean }>`
   padding: 16px;
   border: none;
   outline: none;
@@ -72,8 +75,9 @@ const Input = styled.input<{ $status: StatusType; $error?: boolean }>`
 
   border-radius: 8px;
   border: 1px solid;
-  border-color: ${({ $status, $error }) => {
+  border-color: ${({ $status, $error, $changeable }) => {
     if ($error) return `var(--Light-Red, #F95B6E)`;
+    if ($changeable) return `var(--white-high-emphasis-87, rgba(255, 255, 255, 0.87));`;
     switch ($status) {
       case 'focus':
       case 'filled':


### PR DESCRIPTION
User-Info 페이지 디자인 변경사항 적용했습니다

- 기존 중복확인 버튼은 "닉네임이 수정된 경우" && "중복확인이 아직 안 이루어진 경우"에만 표시됩니다
- 중복확인을 성공적으로 마쳤다면 폼이 하이라이트되고, "변경가능한 닉네임입니다." 문구가 표시됩니다

프로필 사진만 최종적으로 나오면 갈아끼우면 될 것 같습니다