### PR TITLE
fix: 로그인 여부 판별 조건 변경

### DIFF
--- a/libs/client/AuthProvider.tsx
+++ b/libs/client/AuthProvider.tsx
@@ -7,12 +7,14 @@ import { useAuthStore } from '../store/Providers/AuthStoreProvider';
 import { useProfileStore } from '../store/Providers/ProfileStoreProvider';
 import { useTicketStore } from '../store/Providers/TicketStoreProvider';
 import { refresh } from '@/libs/client/createAxiosInstance';
+import { useGetNeedSignup } from '@/libs/apis/auth';
 
 export function AuthProvider() {
   const { isLogin, login, logout } = useAuthStore((state) => state);
   const setProfile = useProfileStore((state) => state.setProfile);
   const setTickets = useTicketStore((state) => state.setTickets);
 
+  const { data: isAlreadySignup, isSuccess: isGetNeedSignupSuccess } = useGetNeedSignup();
   const { data: updateProfile, refetch: getProfile, isSuccess: isGetProfileSuccess } = useGetProfile();
   const { data: tickets, refetch: getTickets, isSuccess: isGetTicketsSuccess } = useGetTickets();
 
@@ -58,11 +60,10 @@ export function AuthProvider() {
   }, [signIn, signOut]);
 
   useEffect(() => {
-    const refreshToken = localStorage.getItem('refreshToken');
-    if (refreshToken) {
+    if (isGetNeedSignupSuccess && isAlreadySignup) {
       login();
     }
-  }, [login]);
+  }, [isGetNeedSignupSuccess, isAlreadySignup, login]);
 
   useEffect(() => {
     if (isLogin) {


### PR DESCRIPTION
AuthStore의 로그인 판별 조건을 
localStorage의 refreshToken에서 받아오는 것에서
자체적으로 구현한 signUp을 마쳤는지 서버에서 받아오는 것으로 변경했습니다